### PR TITLE
avoid `promote` for homogeneous tuples

### DIFF
--- a/src/CheckedSizeProduct.jl
+++ b/src/CheckedSizeProduct.jl
@@ -70,4 +70,7 @@ module CheckedSizeProduct
         p = promote(t...)
         checked_size_product_impl(p)  # avoid infinite recursion in case `promote` is quirky
     end
+    function checked_size_product(t::NonemptyNTuple)
+        checked_size_product_impl(t)
+    end
 end


### PR DESCRIPTION
According to Cthulhu's `descend`, `promote` doesn't get optimized out otherwise:

```julia
using CheckedSizeProduct
function f(t::Tuple{Int, Vararg{Int}})
    p = checked_size_product(t)
    if p isa Int
        p
    else
        throw(nothing)
    end
end
using Cthulhu: descend
descend(f, Tuple{Tuple{Vararg{Int, 15}}})
```