### PR TITLE
better effects

### DIFF
--- a/src/CheckedSizeProduct.jl
+++ b/src/CheckedSizeProduct.jl
@@ -50,6 +50,23 @@ module CheckedSizeProduct
         (a, have_overflow)
     end
 
+    @assume_terminates_locally function any_impl(f, t::NonemptyNTuple)
+        a = f(first(t))::Bool  # assuming no `missing`
+        for i ∈ eachindex(t)[2:end]
+            b = f(t[i])::Bool
+            a |= b
+        end
+        a
+    end
+
+    # define singleton types for these functions to be able to dispatch on them
+    function is_negative(x)
+        x < 0
+    end
+    function is_typemax(x)
+        x == typemax(x)
+    end
+
     const HasGoodEffects = Union{
         Int8, Int16, Int32, Int64, Int128,
     }
@@ -57,18 +74,27 @@ module CheckedSizeProduct
     function checked_dims(t::NonemptyNTuple)
         checked_dims_impl(t)
     end
+    function any_(f, t::NonemptyNTuple)
+        any_impl(f, t)
+    end
     @static if isdefined(Base, Symbol("@assume_effects"))
         Base.@assume_effects :nothrow function checked_dims(
             t::(NonemptyNTuple{T} where {T <: HasGoodEffects}),
         )
             checked_dims_impl(t)
         end
+        Base.@assume_effects :nothrow function any_(
+            f::Union{typeof(iszero), typeof(is_negative), typeof(is_typemax)},
+            t::(NonemptyNTuple{T} where {T <: HasGoodEffects}),
+        )
+            any_impl(f, t)
+        end
     end
 
     function checked_size_product_impl(t::NonemptyNTuple{T, N}) where {T, N}
-        any_is_zero     = any(iszero, t)::Bool
-        any_is_negative = any(<(false), t)::Bool
-        any_is_typemax  = any(==(typemax(T)), t)::Bool
+        any_is_zero = any_(iszero, t)
+        any_is_negative = any_(is_negative, t)
+        any_is_typemax = any_(is_typemax, t)
         (product, have_overflow) = checked_dims(t)
         is_not_representable = have_overflow & !any_is_zero
         if !(any_is_negative | any_is_typemax | is_not_representable)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,18 +2,6 @@ using CheckedSizeProduct
 using Test
 using Aqua: Aqua
 
-function test_constant_folding(func, return_value)
-    vec = code_typed(func, Tuple{})
-    p = only(vec)
-    code_info = first(p)
-    code = try
-        code_info.code
-    catch
-        nothing
-    end
-    @test repr(only(code)) == repr(:(return $return_value)) skip=(code isa Nothing)
-end
-
 @testset "CheckedSizeProduct.jl" begin
     @testset "Code quality (Aqua.jl)" begin
         Aqua.test_all(CheckedSizeProduct)
@@ -84,15 +72,6 @@ end
                     @test ref === checked_size_product((a, b, c, true))
                 end
             end
-        end
-    end
-    @testset "does it constant fold?" begin
-        function func()
-            t = ntuple(identity, Val{7}())
-            checked_size_product(t)
-        end
-        if v"1.10" ≤ VERSION
-            test_constant_folding(func, factorial(7))
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,18 @@ using CheckedSizeProduct
 using Test
 using Aqua: Aqua
 
+function test_constant_folding(func, return_value)
+    vec = code_typed(func, Tuple{})
+    p = only(vec)
+    code_info = first(p)
+    code = try
+        code_info.code
+    catch
+        nothing
+    end
+    @test repr(only(code)) == repr(:(return $return_value)) skip=(code isa Nothing)
+end
+
 @testset "CheckedSizeProduct.jl" begin
     @testset "Code quality (Aqua.jl)" begin
         Aqua.test_all(CheckedSizeProduct)
@@ -72,6 +84,15 @@ using Aqua: Aqua
                     @test ref === checked_size_product((a, b, c, true))
                 end
             end
+        end
+    end
+    @testset "does it constant fold?" begin
+        function func()
+            t = ntuple(identity, Val{7}())
+            checked_size_product(t)
+        end
+        if v"1.10" ≤ VERSION
+            test_constant_folding(func, factorial(7))
         end
     end
 end


### PR DESCRIPTION
* tweak effect assumptions
    * use `:terminates_locally` instead of `:terminates_globally`
        * apply it independently of element type
    * apply `:nothrow` for known good types
* custom `any`