### PR TITLE
don't do promotion and don't accept a heterogeneous tuple as input

### DIFF
--- a/src/CheckedSizeProduct.jl
+++ b/src/CheckedSizeProduct.jl
@@ -2,7 +2,7 @@ module CheckedSizeProduct
     export checked_size_product
 
     """
-        checked_size_product(::Tuple{Any, Vararg})
+        checked_size_product(size_tuple)
 
     In short; a safe product, suitable for computing, e.g., the value of
     `length(dense_array)` from the value of `size(dense_array)`. In case everything
@@ -10,10 +10,16 @@ module CheckedSizeProduct
     tuple. Otherwise, return a `NamedTuple` containing Boolean values with
     information on the encountered problems.
 
-    In more detail; given a nonempty tuple of `Integer`-likes:
-    1. Promote the elements to a common concrete type, say `T`. The user must
-       ensure `T` supports `Base.Checked.mul_with_overflow`, `iszero`, `typemax`,
-       `<` and `==`.
+    In more detail; given `size_tuple`, a nonempty homogeneous tuple of
+    `Integer`-likes:
+    0. Give the name `T` to `eltype(size_tuple)` for the purposes of this doc
+       string.
+    1. The user must ensure `T` supports:
+        * `Base.Checked.mul_with_overflow`
+        * `iszero`
+        * `typemax`
+        * `<`
+        * `==`
     2. Calculate the product. In case no element is negative, no element is
        `typemax(T)` and the product is representable as `T`, return the product.
        Otherwise, return a `NamedTuple` containing two Boolean properties:
@@ -91,7 +97,7 @@ module CheckedSizeProduct
         end
     end
 
-    function checked_size_product_impl(t::NonemptyNTuple{T, N}) where {T, N}
+    function checked_size_product(t::NonemptyNTuple{T, N}) where {T, N}
         any_is_zero = any_(iszero, t)
         any_is_negative = any_(is_negative, t)
         any_is_typemax = any_(is_typemax, t)
@@ -102,13 +108,5 @@ module CheckedSizeProduct
         else
             (; any_is_negative = any_is_negative, any_is_typemax = any_is_typemax)
         end
-    end
-
-    function checked_size_product(t::NonemptyNTuple{Any})
-        p = promote(t...)
-        checked_size_product_impl(p)  # avoid infinite recursion in case `promote` is quirky
-    end
-    function checked_size_product(t::NonemptyNTuple)
-        checked_size_product_impl(t)
     end
 end

--- a/src/CheckedSizeProduct.jl
+++ b/src/CheckedSizeProduct.jl
@@ -97,7 +97,7 @@ module CheckedSizeProduct
         end
     end
 
-    function checked_size_product(t::NonemptyNTuple{T, N}) where {T, N}
+    function checked_size_product(t::NonemptyNTuple)
         any_is_zero = any_(iszero, t)
         any_is_negative = any_(is_negative, t)
         any_is_typemax = any_(is_typemax, t)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,9 @@ using .ExampleInts: ExampleInt
     @testset "empty input" begin
         @test_throws Exception checked_size_product(())
     end
+    @testset "heterogeneous input" begin
+        @test_throws Exception checked_size_product((Int32(2), Int64(3)))
+    end
     @testset "singleton input" begin
         for T ∈ (Int8, Int16, Int32, Int64, Int128, ExampleInt)
             for x ∈ 0:100

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,14 +66,6 @@ using .ExampleInts: ExampleInt
             end
         end
     end
-    @testset "promotion" begin
-        @test 10 === checked_size_product((Int8(2), 5))
-        @test 10 === checked_size_product((2, Int8(5)))
-        @test Int16(10) === checked_size_product((Int8(2), Int16(5)))
-        @test Int16(10) === checked_size_product((Int16(2), Int8(5)))
-        @test ExampleInt(6) === checked_size_product((2, ExampleInt(3)))
-        @test ExampleInt(6) === checked_size_product((ExampleInt(2), 3))
-    end
     @testset "input includes negative" begin
         for t ∈ (
             (-1,), (-1, 1), (1, -1), (0, -1), (-1, 0), (-1, -1),
@@ -135,14 +127,15 @@ using .ExampleInts: ExampleInt
                 for z ∈ ran
                     for T ∈ (Int8, Int16, Int32, Int64, Int128, ExampleInt)
                         ref = T(prod((x, y, z)))
+                        o = T(1)
                         a = T(x)
                         b = T(y)
                         c = T(z)
                         @test ref === checked_size_product((a, b, c))
-                        @test ref === checked_size_product((true, a, b, c))
-                        @test ref === checked_size_product((a, true, b, c))
-                        @test ref === checked_size_product((a, b, true, c))
-                        @test ref === checked_size_product((a, b, c, true))
+                        @test ref === checked_size_product((o, a, b, c))
+                        @test ref === checked_size_product((a, o, b, c))
+                        @test ref === checked_size_product((a, b, o, c))
+                        @test ref === checked_size_product((a, b, c, o))
                     end
                 end
             end


### PR DESCRIPTION
The promotion seems more likely to hide bugs from the user than to be helpful.